### PR TITLE
Use Agda.Builtin modules. Issue #11.

### DIFF
--- a/src/Prelude/Bool.agda
+++ b/src/Prelude/Bool.agda
@@ -6,9 +6,8 @@ open import Agda.Primitive
 open import Prelude.Monoidal.Unit
 open import Prelude.Monoidal.Void
 
-module 𝟚↑ ..{ℓ} where
-  data 𝟚 : Set ℓ where
-    ff tt : 𝟚
+module 𝟚 where
+  open import Agda.Builtin.Bool renaming (Bool to 𝟚; false to ff; true to tt) public
 
   not : 𝟚 → 𝟚
   not ff = tt
@@ -46,20 +45,12 @@ module 𝟚↑ ..{ℓ} where
   {-# DISPLAY or p q = p ∨ q #-}
   {-# DISPLAY and p q = p ∧ q #-}
 
-module 𝟚 where
-  open 𝟚↑ {lzero} public
-
-open 𝟚↑ public
-  using (ff)
-  using (tt)
 open 𝟚 public
   using (𝟚)
+  using (ff)
+  using (tt)
   using (_∧_)
   using (_∨_)
   using (if_then_else_)
   using (⟦_⟧)
   hiding (module 𝟚)
-
-{-# BUILTIN BOOL 𝟚 #-}
-{-# BUILTIN FALSE ff #-}
-{-# BUILTIN TRUE tt #-}

--- a/src/Prelude/Char.agda
+++ b/src/Prelude/Char.agda
@@ -11,14 +11,13 @@ open import Prelude.String
 open import Prelude.Unsafe
 
 module Char where
-  postulate
-    Char : Set
-  {-# BUILTIN CHAR Char #-}
+  open import Agda.Builtin.Char public
+    using (Char)
+    using (primCharEquality)
+    using (primCharToNat)
 
-  primitive
-    primCharEquality : Char → Char → 𝟚
-    primCharToNat : Char → Nat
-    primShowChar : Char → String
+  open import Agda.Builtin.String public
+    using (primShowChar)
 
   show : Char → String
   show = primShowChar

--- a/src/Prelude/Integer.agda
+++ b/src/Prelude/Integer.agda
@@ -6,12 +6,10 @@ open import Agda.Primitive
 open import Prelude.Natural
 
 module Int where
-  data Int : Set where
-    pos  : Nat → Int
-    negS : Nat → Int
-  {-# BUILTIN INTEGER Int #-}
-  {-# BUILTIN INTEGERPOS pos #-}
-  {-# BUILTIN INTEGERNEGSUC negS #-}
+  open import Agda.Builtin.Int public
+    using (Int)
+    using (pos)
+    renaming (negsuc to negS)
 
   record ⊆ (A : Set) : Set where
     no-eta-equality

--- a/src/Prelude/List.agda
+++ b/src/Prelude/List.agda
@@ -359,14 +359,14 @@ module List where
       : ∀ ..{ℓ}
       → {A : Set ℓ}
       → (xs : List A)
-      → [] ++ xs ≡ xs
+      → ([] ++ xs) ≡ xs
     λ⇒ xs = ≡.idn
 
     λ⇐
       : ∀ ..{ℓ}
       → {A : Set ℓ}
       → (xs : List A)
-      → xs ≡ [] ++ xs
+      → xs ≡ ([] ++ xs)
     λ⇐ [] = ≡.idn
     λ⇐ (x ∷ xs) = ≡.ap¹ (_∷_ x) (λ⇐ xs)
 
@@ -374,7 +374,7 @@ module List where
       : ∀ ..{ℓ}
       → {A : Set ℓ}
       → (xs : List A)
-      → xs ++ [] ≡ xs
+      → (xs ++ []) ≡ xs
     ρ⇒ [] = ≡.idn
     ρ⇒ (x ∷ xs) = ≡.ap¹ (_∷_ x) (ρ⇒ xs)
 
@@ -382,7 +382,7 @@ module List where
       : ∀ ..{ℓ}
       → {A : Set ℓ}
       → (xs : List A)
-      → xs ≡ xs ++ []
+      → xs ≡ (xs ++ [])
     ρ⇐ [] = ≡.idn
     ρ⇐ (x ∷ xs) = ≡.ap¹ (_∷_ x) (ρ⇐ xs)
 
@@ -391,7 +391,7 @@ module List where
       → {A : Set ℓ}
       → (xs : List A)
       → {ys zs : List A}
-      → (xs ++ ys) ++ zs ≡ xs ++ (ys ++ zs)
+      → ((xs ++ ys) ++ zs) ≡ (xs ++ (ys ++ zs))
     α⇒ [] = ≡.idn
     α⇒ (x ∷ xs) = ≡.ap¹ (_∷_ x) (α⇒ xs)
 
@@ -400,7 +400,7 @@ module List where
       → {A : Set ℓ}
       → (xs : List A)
       → {ys zs : List A}
-      → xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
+      → (xs ++ (ys ++ zs)) ≡ ((xs ++ ys) ++ zs)
     α⇐ [] = ≡.idn
     α⇐ (x ∷ xs) = ≡.ap¹ (_∷_ x) (α⇐ xs)
 
@@ -436,7 +436,7 @@ module List where
       : {A B : Set}
       → ∀ xs {ys : List A}
       → {f : A → B}
-      → map f xs ++ map f ys ≡ map f (xs ++ ys)
+      → (map f xs ++ map f ys) ≡ (map f (xs ++ ys))
     map-++ [] =
       ≡.idn
     map-++ (x ∷ xs) =
@@ -444,7 +444,7 @@ module List where
 
     ∷-inj
       : {A : Set}{x y : A}{xs ys : List A}
-      → x ∷ xs ≡ y ∷ ys
+      → (x ∷ xs) ≡ (y ∷ ys)
       → (x ≡ y) ⊗ (xs ≡ ys)
     ∷-inj refl = refl , refl
 

--- a/src/Prelude/Natural.agda
+++ b/src/Prelude/Natural.agda
@@ -18,10 +18,11 @@ module Nat where
   infix 0 _≥?_
   infix 0 _>?_
 
-  data Nat : Set where
-    ze : Nat
-    su_ : Nat → Nat
-  {-# BUILTIN NATURAL Nat #-}
+  open import Agda.Builtin.Nat public
+    using (Nat)
+    using (_+_)
+    using (_-_)
+    renaming (zero to ze; suc to su_)
 
   record ⊆ (A : Set) : Set where
     no-eta-equality
@@ -88,16 +89,6 @@ module Nat where
     using (stop)
     using (step)
   open ≤
-
-  _+_ : (m n : Nat) → Nat
-  (ze) + n = n
-  (su m) + n = su (m + n)
-  {-# BUILTIN NATPLUS _+_ #-}
-
-  _*_ : (m n : Nat) → Nat
-  (ze) * n = ze
-  (su m) * n = n + (m * n)
-  {-# BUILTIN NATTIMES _*_ #-}
 
   min : (m n : Nat) → Nat
   min ze n = ze

--- a/src/Prelude/Path.agda
+++ b/src/Prelude/Path.agda
@@ -10,12 +10,7 @@ open import Prelude.Monoidal.Product.Indexed
 open import Prelude.Monoidal.Unit
 open import Prelude.Point
 
-infix 0 _≡_
-
-data _≡_ ..{ℓ} {A : Set ℓ} (a : A) : A → Set ℓ where
-  refl : a ≡ a
-{-# BUILTIN EQUALITY _≡_ #-}
-{-# BUILTIN REFL refl #-}
+open import Agda.Builtin.Equality public
 
 module ≡ where
 
@@ -120,10 +115,10 @@ module ≡ where
 
   module ≾ where
     idn
-      : ∀ ..{ℓ}
+      : ∀ {ℓ}
       → {A : Set ℓ}
       → {a : A}
-      → refl {a = a} ≡ refl {a = a}
+      → refl {x = a} ≡ refl {x = a}
     idn = #.idn
 
     cmp
@@ -154,7 +149,7 @@ module ≡ where
       → {a b : A}
       → {ρ₀ ρ₁ : a ≡ b}
       → (α : ρ₀ ≡ ρ₁)
-      → ρ₀ #.⁻¹ ≡ ρ₁ #.⁻¹
+      → (ρ₀ #.⁻¹) ≡ (ρ₁ #.⁻¹)
     inv #.idn = #.idn
 
   module ⊢ where

--- a/src/Prelude/Size.agda
+++ b/src/Prelude/Size.agda
@@ -5,11 +5,12 @@ module Prelude.Size where
 open import Agda.Primitive
 
 module Size where
-  {-# BUILTIN SIZEUNIV U #-}
-  {-# BUILTIN SIZE Size #-}
-  {-# BUILTIN SIZELT <_ #-}
-  {-# BUILTIN SIZESUC ↑_ #-}
-  {-# BUILTIN SIZEINF ∞ #-}
+  open import Agda.Builtin.Size public
+    renaming (SizeU to U)
+    using (Size)
+    renaming (Size<_ to <_)
+    using (↑_)
+    renaming (ω to ∞)
 
 open Size public
   using (Size)

--- a/src/Prelude/String.agda
+++ b/src/Prelude/String.agda
@@ -10,13 +10,10 @@ open import Prelude.Path
 open import Prelude.Unsafe
 
 module String where
-  postulate
-    String : Set
-  {-# BUILTIN STRING String #-}
-
-  primitive
-    primStringEquality : String → String → 𝟚
-    primShowString : String → String
+  open import Agda.Builtin.String public
+    using (String)
+    using (primStringEquality)
+    using (primShowString)
 
   _≟_ : (s₀ s₁ : String) → Decidable (s₀ ≡ s₁)
   s₀ ≟ s₁ with primStringEquality s₀ s₁


### PR DESCRIPTION
In general I imported the Agda.Builtin modules public and renamed the bindings to match what agda-prelude already had. I left the fixity precedences alone, and some of the Agda.Builtin precedences differ from the agda-prelude ones. In particular I had to add parentheses for some equality types in the List module.